### PR TITLE
Fix Streamlit rerun usage and guard missing DataFrame

### DIFF
--- a/app.py
+++ b/app.py
@@ -129,10 +129,10 @@ def main() -> None:
                 yes_col, no_col = st.columns(2)
                 if yes_col.button("Yes"):
                     st.session_state.join_choice = True
-                    st.experimental_rerun()
+                    st.rerun()
                 if no_col.button("No"):
                     st.session_state.join_choice = False
-                    st.experimental_rerun()
+                    st.rerun()
                 for f, frame in zip(uploaded_files, frames):
                     st.caption(f"{f.name}: {len(frame)} rows, {len(frame.columns)} columns")
             elif choice:
@@ -145,7 +145,7 @@ def main() -> None:
                     st.warning(f"Join failed: {res['reason']}")
                     if st.button("Back to sources"):
                         st.session_state.join_choice = False
-                        st.experimental_rerun()
+                        st.rerun()
             else:
                 tabs = st.tabs([f.name for f in uploaded_files])
                 for i, (tab, frame) in enumerate(zip(tabs, frames)):
@@ -166,6 +166,8 @@ def main() -> None:
             st.dataframe(frames[0].head(100), use_container_width=True)
 
     df = st.session_state.get("current_df")
+    if df is None:
+        st.stop()
 
     with st.sidebar:
         if "filter_state" not in st.session_state:
@@ -242,7 +244,7 @@ def main() -> None:
             if len(st.session_state.history) > 1:
                 st.session_state.history.pop()
                 st.session_state.filter_state = st.session_state.history[-1]
-                st.experimental_rerun()
+                st.rerun()
 
     filter_state = st.session_state.get("filter_state", {})
     fields = filter_state.get("fields_selection", [])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration to ensure project root importability."""
+
+import sys
+from pathlib import Path
+
+# Add the project root to ``sys.path`` so tests can import ``app`` directly.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+


### PR DESCRIPTION
## Summary
- Replace deprecated `st.experimental_rerun` with `st.rerun`
- Guard against missing `current_df` to prevent AttributeError when no dataset is selected
- Add pytest configuration to ensure project root is importable during tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a563df4c3c832d846431d215cf2865