### PR TITLE
Trim whitespace from join keys

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,7 @@ def join_frames(frames: List[pd.DataFrame]) -> Tuple[pd.DataFrame, Dict[str, int
         for col in common:
             series = frame[col].astype("string")
             series = series.str.replace(r"\.0+$", "", regex=True)
+            series = series.str.strip()
             frame[col] = series
         return frame
 

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -34,3 +34,13 @@ def test_no_join_download_names():
     names = ['first.csv', 'second.csv']
     files = [f"{Path(n).stem}-edited.csv" for n in names]
     assert files == ['first-edited.csv', 'second-edited.csv']
+
+
+def test_join_strips_whitespace():
+    df1 = pd.DataFrame({'id': ['1 ', ' 2'], 'v1': [10, 20]})
+    df2 = pd.DataFrame({'id': ['1', '2'], 'v2': [30, 40]})
+    res = perform_join([df1, df2])
+    assert res['ok']
+    assert res['meta']['outputRows'] == 2
+    assert res['data']['v1'].isna().sum() == 0
+    assert res['data']['v2'].isna().sum() == 0


### PR DESCRIPTION
## Summary
- Strip leading and trailing whitespace from common columns before joining datasets
- Add regression test ensuring join handles whitespace-only differences

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a5661b727c832d8759113629e97edf